### PR TITLE
Use Qt's date parser for parsing RSS dates (breaks compat with old SFOS)

### DIFF
--- a/src/dateparser.h
+++ b/src/dateparser.h
@@ -15,42 +15,9 @@ class DateParser : public QObject
 public:
     Q_INVOKABLE QDateTime parse(const QString& dateString) const
     {
-        QDateTime d;
-        if (dateString.contains(","))
-        {
-            // Qt::RFC2822Date is not supported by Qt < 5.2, so re-implement it
-            // to stay backwards compatible
-
-            // non-numeric UTC offset representations
-            QMap<QString, long int> timezones;
-            timezones["Z"] = 0;  // "Zulu time" has been used as an nautical
-                                 // alias to GMT since the 1950s
-            timezones["UT"] = 0;
-            timezones["GMT"] = 0;
-            timezones["EST"] = -5 * 3600;
-            timezones["EDT"] = -4 * 3600;
-            timezones["CST"] = -6 * 3600;
-            timezones["CDT"] = -5 * 3600;
-            timezones["MST"] = -7 * 3600;
-            timezones["MDT"] = -6 * 3600;
-            timezones["PST"] = -8 * 3600;
-            timezones["PDT"] = -7 * 3600;
-
-            QStringList parts = dateString.split(' ');
-
-            struct tm tm;
-            setlocale(LC_TIME, "C");
-            strptime(dateString.toLatin1().constData(),
-                     "%a, %d %b %Y %H:%M:%S %z",
-                     &tm);
-            setlocale(LC_TIME, "");
-
-            // get the offset to UTC
-            long int utcOffset = timezones.value(parts.last(),
-                                                 tm.tm_gmtoff);
-            // treat time as UTC and correct timeshift by subtracting the offset
-            d = QDateTime::fromTime_t(timegm(&tm) - utcOffset);
-        }
+        // Qt::RFC2822Date is not supported by Qt < 5.2, so we have to break compatibility
+        // with ancient SFOS versions. A reliable custom implementation would be hard.
+        QDateTime d = QDateTime::fromString(dateString, Qt::RFC2822Date);
 
         if (! d.isValid())
         {


### PR DESCRIPTION
Custom logic for parsing RSS dates was used to keep compatibility
with ancient SFOS whith even older Qt. Recent SFOS ships Qt 5.6 so
we can use Qt's date parser for parsing RSS dates.

The custom parser choked on dates like "21 Mar 2021 09:40:00 +0100"
(no week day given).

From Qt 5.6 docs:

"RFC 2822, RFC 850 and RFC 1036 format: either [ddd,] dd MMM yyyy hh:mm[:ss] +/-TZ or
ddd MMM dd yyyy hh:mm[:ss] +/-TZ for combined dates and times."

(Latest Qt 5.15 explains even more special cases.)