### PR TITLE
Explicitly define color for scroll bars (workaround for Silica bug)

### DIFF
--- a/qml/pages/FeedsPage.qml
+++ b/qml/pages/FeedsPage.qml
@@ -236,7 +236,7 @@ Page {
             text: qsTr("Pull down to add feeds.")
         }
 
-        ScrollDecorator { }
+        ScrollDecorator { color: palette.primaryColor }
     }
 
     FancyScroller {

--- a/qml/pages/LicensePage.qml
+++ b/qml/pages/LicensePage.qml
@@ -34,6 +34,6 @@ Page {
 
         }
 
-        ScrollDecorator { }
+        ScrollDecorator { color: palette.primaryColor }
     }
 }

--- a/qml/pages/ResourcesPage.qml
+++ b/qml/pages/ResourcesPage.qml
@@ -40,7 +40,7 @@ Page {
             length: -1
         }
 
-        ScrollDecorator { }
+        ScrollDecorator { color: palette.primaryColor }
     }
 
     /*
@@ -74,7 +74,7 @@ Page {
             }//Repeater
         }
 
-        ScrollDecorator { }
+        ScrollDecorator { color: palette.primaryColor }
     }
     */
 }

--- a/qml/pages/SourceEditDialog.qml
+++ b/qml/pages/SourceEditDialog.qml
@@ -182,7 +182,7 @@ Dialog {
 
         }//Column
 
-        ScrollDecorator { }
+        ScrollDecorator { color: palette.primaryColor }
 
     }//Flickable
 

--- a/qml/pages/SourcesPage.qml
+++ b/qml/pages/SourcesPage.qml
@@ -517,7 +517,7 @@ Page {
             height: gridview.cellHeight
         }
 
-        ScrollDecorator { }
+        ScrollDecorator { color: palette.primaryColor }
     }
 
     MouseArea {

--- a/qml/pages/ViewPage.qml
+++ b/qml/pages/ViewPage.qml
@@ -549,7 +549,7 @@ Page {
 
         }
 
-        ScrollDecorator { }
+        ScrollDecorator { color: palette.primaryColor }
     }
 
     BusyIndicator {


### PR DESCRIPTION
The ScrollDecorator element does not follow Silica theming (which is
a bug in Silica). Both VerticalScrollDecorator and HorizontalScrollDecorator
use the primary color by default.

Consider using Vertical/Horizontal... directly where only one scroll bar
is ever used. Explicitly specifying "flickable: ..." would also benefit
performance.

(Defining "color: palette.primaryColor" is not required with Vertical/HorizontalScrollDecorator.)