### PR TITLE
Trim source url on add / update

### DIFF
--- a/qml/pages/SourcesModel.qml
+++ b/qml/pages/SourcesModel.qml
@@ -8,6 +8,7 @@ ListModel {
     signal modelChanged
 
     function addSource(name, url, color) {
+        url = url.trim();
         var sourceId = database.addSource(name, url, color);
         append({
                    "sourceId": sourceId,
@@ -24,6 +25,7 @@ ListModel {
     }
 
     function changeSource(sourceId, name, url, color) {
+        url = url.trim();
         database.changeSource(sourceId, name, url, color);
 
         for (var i = 0; i < count; i++) {


### PR DESCRIPTION
A few times now, I have had the issue of not being able to refresh my feeds, because I had a trailing space in my url.
This pull-request fixes that issue, by trimming the url in the source model add & update functions.

Tested on my Xperia X.