### PR TITLE
[Add] Setting for new top menu item `All read & Refresh all`

### DIFF
--- a/qml/harbour-tidings.qml
+++ b/qml/harbour-tidings.qml
@@ -96,6 +96,12 @@ ApplicationWindow
     }
 
     ConfigValue {
+        id: configEnableRefreshCombined
+        key: "menu-enable-refresh-combined"
+        value: "1"
+    }
+
+    ConfigValue {
         id: configLoadImages
         key: "view-load-images"
         value: "0"

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -42,6 +42,24 @@ Page {
 
             TextSwitch {
                 width: parent.width
+                text: qsTr("Enable 'All read & Refresh all'")
+                description: qsTr("Whether to show or hide the top menu item for 'All read & Refresh all'")
+                automaticCheck: false
+                checked: configEnableRefreshCombined.booleanValue
+
+                onClicked: {
+                    configEnableRefreshCombined.value =
+                            configEnableRefreshCombined.booleanValue ? "0" : "1";
+                }
+            }
+
+            Item {
+                width: 1
+                height: Theme.paddingLarge
+            }
+
+            TextSwitch {
+                width: parent.width
                 text: qsTr("Load images automatically")
                 description: qsTr("If disabled, embedded images are not loaded automatically.")
                 automaticCheck: false

--- a/qml/pages/SourcesPage.qml
+++ b/qml/pages/SourcesPage.qml
@@ -249,6 +249,7 @@ Page {
                 }
             }
             MenuItem {
+                visible: configEnableRefreshCombined.booleanValue
                 text: newsBlendModel.busy ? qsTr("Abort refreshing")
                                           : qsTr("All read & Refresh all")
 


### PR DESCRIPTION
Because of the missing build for aarch64, I built the app myself.
Because of that, I found the new pulldown menu item for 'All read & Refresh all'. I have selected that item a few times erroneously (therefore losing items which I did not read yet), so I created a setting for it.