### PR TITLE
Show all feeds on attached page

### DIFF
--- a/qml/harbour-tidings.qml
+++ b/qml/harbour-tidings.qml
@@ -84,6 +84,12 @@ ApplicationWindow
     }
 
     ConfigValue {
+        id: configAllFeedsSorter
+        key: "all-feeds-sort-by"
+        value: "latestFirst"
+    }
+
+    ConfigValue {
         id: configFeedSorter
         key: "feed-sort-by"
         value: "feedOnlyLatestFirst"

--- a/qml/pages/FeedsPage.qml
+++ b/qml/pages/FeedsPage.qml
@@ -14,6 +14,7 @@ Page {
             // WARNING: This inevitably breaks if it becomes possible to reach the
             // combined news page from somewhere other than "SourcesPage".
             newsBlendModel.isBlendModeEnabled = true;
+            listview.currentIndex = -1
         }
 
         // Uncomment to debug page changes.

--- a/qml/pages/FeedsPage.qml
+++ b/qml/pages/FeedsPage.qml
@@ -5,17 +5,13 @@ Page {
     id: page
     objectName: "FeedsPage"
 
-    function positionAtFirst(feedUrl)
-    {
-        var idx = newsBlendModel.firstOfFeed(feedUrl);
-        if (idx !== -1)
-        {
-            listview.positionViewAtIndex(idx,
-                                         ListView.Beginning);
+    allowedOrientations: Orientation.All
+
+    onStatusChanged: {
+        if (status == PageStatus.Deactivated) {
+            newsBlendModel.isBlendModeEnabled = true; // show all feeds again
         }
     }
-
-    allowedOrientations: Orientation.All
 
     Connections {
         target: navigationState

--- a/qml/pages/FeedsPage.qml
+++ b/qml/pages/FeedsPage.qml
@@ -8,9 +8,18 @@ Page {
     allowedOrientations: Orientation.All
 
     onStatusChanged: {
-        if (status == PageStatus.Deactivated) {
-            newsBlendModel.isBlendModeEnabled = true; // show all feeds again
+        if (status == PageStatus.Inactive && pageStack.currentPage.objectName == 'SourcesPage') {
+            // Show all feeds again if we returned to the root page, i.e. the
+            // feed sources overview page.
+            // WARNING: This inevitably breaks if it becomes possible to reach the
+            // combined news page from somewhere other than "SourcesPage".
+            newsBlendModel.isBlendModeEnabled = true;
         }
+
+        // Uncomment to debug page changes.
+        // if (status == PageStatus.Inactive) {
+        //     console.log("FeedsPage inactive: status =", status, "depth =", pageStack.depth, "current = ", pageStack.currentPage.objectName)
+        // }
     }
 
     Connections {

--- a/qml/pages/NewsBlendModel.qml
+++ b/qml/pages/NewsBlendModel.qml
@@ -87,7 +87,9 @@ NewsModel {
 
     property variant feedSortersCombined: [
         latestFirstSorter,
-        oldestFirstSorter
+        oldestFirstSorter,
+        feedSourceLatestFirstSorter,
+        feedSourceOldestFirstSorter
     ]
 
     property FeedLoader _feedLoader: FeedLoader {

--- a/qml/pages/NewsBlendModel.qml
+++ b/qml/pages/NewsBlendModel.qml
@@ -10,8 +10,13 @@ NewsModel {
 
     sortMode: feedSorter.sortMode
 
+    // whether to blend models or show a single feed
+    // Must be set to "true" initially so the attached feeds page shows all
+    // feeds on startup.
+    property bool isBlendModeEnabled: true
+
     // the sorter for this model
-    property FeedSorter feedSorter: _getFeedSorter(configFeedSorter.value)
+    property FeedSorter feedSorter: _getFeedSorter(isBlendModeEnabled ? configAllFeedsSorter.value : configFeedSorter.value)
 
     // the list of all feed sources to load.
     property variant sources: []

--- a/qml/pages/NewsBlendModel.qml
+++ b/qml/pages/NewsBlendModel.qml
@@ -80,6 +80,16 @@ NewsModel {
         feedOnlyOldestFirstSorter
     ]
 
+    property variant feedSortersSingle: [
+        feedOnlyLatestFirstSorter,
+        feedOnlyOldestFirstSorter
+    ]
+
+    property variant feedSortersCombined: [
+        latestFirstSorter,
+        oldestFirstSorter
+    ]
+
     property FeedLoader _feedLoader: FeedLoader {
         property string feedName
 

--- a/qml/pages/SortSelectorPage.qml
+++ b/qml/pages/SortSelectorPage.qml
@@ -18,7 +18,7 @@ Page {
         id: listview
 
         anchors.fill: parent
-        model: newsBlendModel.feedSorters
+        model: newsBlendModel.isBlendModeEnabled ? newsBlendModel.feedSortersCombined : newsBlendModel.feedSortersSingle
 
         header: PageHeader {
             title: qsTr("Sort by")

--- a/qml/pages/SortSelectorPage.qml
+++ b/qml/pages/SortSelectorPage.qml
@@ -41,15 +41,15 @@ Page {
             }
 
             onClicked: {
-                function closure(sorter)
+                function closure(sorter, targetConfig)
                 {
                     return function()
                     {
-                        configFeedSorter.value = sorter.key;
+                        targetConfig.value = sorter.key
                     }
                 }
 
-                _callback = closure(modelData);
+                _callback = closure(modelData, newsBlendModel.isBlendModeEnabled ? configAllFeedsSorter : configFeedSorter);
                 pageStack.pop();
             }
         }

--- a/qml/pages/SourcesPage.qml
+++ b/qml/pages/SourcesPage.qml
@@ -413,8 +413,8 @@ Page {
                 onClicked: {
                     if (page.editMode === 0 && totalCount !== 0)
                     {
+                        newsBlendModel.isBlendModeEnabled = false; // show a single feed
                         newsBlendModel.selectedFeed = item.url;
-                        feedsPage.positionAtFirst(item.url);
                         pageStack.navigateForward();
                     }
                     else if (page.editMode === 1)


### PR DESCRIPTION
This makes sure the attached page always shows all feeds combined and not the entries of the last feed that has been selected.