### PR TITLE
Fixed article title and background image not showing in Cover

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -25,7 +25,7 @@ CoverBackground {
     Image {
         id: backgroundImage
         visible: coverAdaptor.thumbnail !== "" &&
-                 (coverAdaptor.currentPage === "ViewPage" ||
+                 (coverAdaptor.currentPage === "ViewPageProxy" ||
                   coverAdaptor.currentPage === "WebPage") &&
                  status === Image.Ready
         anchors.fill: parent
@@ -213,7 +213,7 @@ CoverBackground {
 
     // News Item
     Column {
-        visible: (coverAdaptor.currentPage === "ViewPage" ||
+        visible: (coverAdaptor.currentPage === "ViewPageProxy" ||
                   coverAdaptor.currentPage === "WebPage")
 
         anchors.left: parent.left
@@ -273,7 +273,7 @@ CoverBackground {
     // [previous] and [next]
     CoverActionList {
         enabled: ! coverAdaptor.busy &&
-                 coverAdaptor.currentPage === "ViewPage" &&
+                 coverAdaptor.currentPage === "ViewPageProxy" &&
                  coverAdaptor.hasPrevious &&
                  coverAdaptor.hasNext
 
@@ -295,7 +295,7 @@ CoverBackground {
     // [previous] only
     CoverActionList {
         enabled: ! coverAdaptor.busy &&
-                 coverAdaptor.currentPage === "ViewPage" &&
+                 coverAdaptor.currentPage === "ViewPageProxy" &&
                  coverAdaptor.hasPrevious &&
                  ! coverAdaptor.hasNext
 
@@ -310,7 +310,7 @@ CoverBackground {
     // [next] only
     CoverActionList {
         enabled: ! coverAdaptor.busy &&
-                 coverAdaptor.currentPage === "ViewPage" &&
+                 coverAdaptor.currentPage === "ViewPageProxy" &&
                  ! coverAdaptor.hasPrevious &&
                  coverAdaptor.hasNext
 


### PR DESCRIPTION
Showing article title and background image in cover got broken when ViewPage was replaced with ViewPageProxy (to enable swiping to next article). Fixed by checking if coverAdaptor.currentPage === "ViewPageProxy" instead of ViewPage. Fixes #81 