### PR TITLE
Fixed article hint visibility

### DIFF
--- a/qml/pages/ViewPage.qml
+++ b/qml/pages/ViewPage.qml
@@ -550,10 +550,4 @@ Item {
         anchors.centerIn: parent
         size: BusyIndicatorSize.Large
     }
-
-    HintLoader {
-        hint: articleHint
-        when: configHintsEnabled.booleanValue &&
-              page.status === PageStatus.Active
-    }
 }

--- a/qml/pages/ViewPageProxy.qml
+++ b/qml/pages/ViewPageProxy.qml
@@ -57,4 +57,10 @@ Dialog {
             }
         }
     }
+
+    HintLoader {
+        hint: articleHint
+        when: configHintsEnabled.booleanValue &&
+              page.status === PageStatus.Active
+    }
 }


### PR DESCRIPTION
Moved article hint from ViewPage to ViewPageProxy to make it properly visible since it was only partially visible. Fixes #84 