### PR TITLE
Fix overlay issue when moving forward from cover

### DIFF
--- a/qml/pages/FeedsPage.qml
+++ b/qml/pages/FeedsPage.qml
@@ -46,10 +46,9 @@ Page {
             pageStack.pop(page, PageStackAction.Immediate);
             listview.currentIndex = 0;
             var props = {
-                "index": 0,
                 "listview": listview
             };
-            pageStack.push("ViewPage.qml", props);
+            pageStack.push("ViewPageProxy.qml", props);
         }
 
         onRefresh: {


### PR DESCRIPTION
Push ViewPageProxy instead of ViewPage when moving to first feed item from the cover. This should fix the case when moving to first item from cover messes the ui. Fixes #87 